### PR TITLE
Launch client-api server correctly.

### DIFF
--- a/client/api/src/routes/routes.ts
+++ b/client/api/src/routes/routes.ts
@@ -8,7 +8,7 @@ import routesController from '../controllers/routesController';
 export class Routes {
   public routes(app): void {
     app.route('/').get((req: Request, res: Response) => {
-      app.status(418).send({
+      res.status(418).send({
         message: "I'm a teapot."
       });
     });


### PR DESCRIPTION
I try to launch xyz servers with docker-compose but client-api server got TypeScript errors. You used app instead of  res for returning teapot. I fixed it.

AS server was not wrong like this
https://github.com/securekey/oauth-xyz-nodejs/blob/master/as/src/routes/routes.ts#L11