### PR TITLE
Fix connections between client-api and as servers

### DIFF
--- a/client/api/src/controllers/routesController.ts
+++ b/client/api/src/controllers/routesController.ts
@@ -13,8 +13,8 @@ import {
 } from '../models/pendingTransaction';
 import * as jose from 'node-jose';
 
-//const asTransactionURL = 'http://as:3000/transaction';
-const asTransactionURL = 'http://host.docker.internal:9834/api/as/transaction';
+const asTransactionURL = 'http://localhost:3000/transaction';
+// const asTransactionURL = 'http://host.docker.internal:9834/api/as/transaction';
 
 const sha3_512_encode = function(toHash: string) {
   return base64url.fromBase64(Buffer.from(sha3_512(toHash), 'hex').toString('base64'));    


### PR DESCRIPTION
Connection between client-api and AS containers failed.
I fixed asTransactionURL in routesController.
This PR and https://github.com/securekey/oauth-xyz-nodejs/pull/4 will make all servers launching and processing correctly with docker-compose.